### PR TITLE
bugfix - flagi CY

### DIFF
--- a/AK_Full.asm
+++ b/AK_Full.asm
@@ -83,7 +83,9 @@ DRUGA 	 DB 'Liczba 2:',13,10,'> @'
 WYNIK    DB 'Wynik:@' 
  
 ; Procedury kalkulatora  
-ADR_DOD 	 MOV H,B  
+ADR_DOD 	 STC ;CPI modyfikuja flage CY wiec przy starcie procedury nalezy ja zresetowac
+	CMC
+	MOV H,B  
 	 MOV L,C  ;przeniesienie pierwszej liczby do HL
 	 DAD D  ;DAD D -> HL + DE = HL
 	 MVI D,0
@@ -101,7 +103,9 @@ ADR_INW 	 MOV A,B  ;przepisanie liczby do A
 	 MOV C,A  
 	 MVI D,0  ;wyzerowanie D żeby nic nie wypisywało na początku wyniku
 	 RET
-ADR_OD MVI L,00H	        
+ADR_OD MVI L,00H
+     STC ;CPI modyfikuja flage CY wiec przy starcie procedury nalezy ja zresetowac
+     CMC	 
 	 MOV A,B  
 	 SUB D  
 	 JC OD_SWAP  

--- a/AK_dodawanie.asm
+++ b/AK_dodawanie.asm
@@ -1,4 +1,6 @@
-ADR_DOD 	 MOV H,B  
+ADR_DOD STC	 
+	 CMC
+	 MOV H,B  
 	 MOV L,C  ;przeniesienie pierwszej liczby do HL
 	 DAD D  ;DAD D -> HL + DE = HL
 	 MVI D,0

--- a/AK_odejmowanie.asm
+++ b/AK_odejmowanie.asm
@@ -6,7 +6,9 @@
 ;Znak wyniku w rejestrze D('-' lub 00H) 
 ;sprawdzenie czy pierwsza liczba jest wieksza od drugiej    
 ;Odejmujemy liczbe 2 od liczby 1, jesli nastapi przenisienie(flaga CY=1) to znaczy ze liczba 2 jest wieksza
-ADR_OD MVI L,00H	        
+ADR_OD STC
+     CMC
+     MVI L,00H	        
 	 MOV A,B  
 	 SUB D  
 	 JC OD_SWAP  


### PR DESCRIPTION
rozkazy CPI modyfikują flagę CY, więc na początku procedur które na tej fladze polegają(dodawanie i odejmowanie) trzeba ją zresetować